### PR TITLE
fix #12: 엔티티 수정

### DIFF
--- a/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Category.java
+++ b/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Category.java
@@ -2,9 +2,9 @@ package com.damoacon.app.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 
 @Entity
 @Table(name="category")
@@ -19,6 +19,7 @@ public class Category {
     @Column(nullable = false,name = "category_name")
     private String category_name;
 
+    @Builder
     public Category(String category_name){
         this.category_name=category_name;
     }

--- a/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Comment.java
+++ b/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Comment.java
@@ -1,7 +1,9 @@
 package com.damoacon.app.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,24 +18,25 @@ public class Comment {
     private Long id;
 
     @ManyToOne
-    @Column(nullable = false, name = "event")
+    @JoinColumn(name="event_id")
+    @NotNull
     private Event event;
 
     @OneToOne
-    @Column(nullable = false, name = "user")
+    @PrimaryKeyJoinColumn
     private User user;
 
     @Column(nullable = true, name = "content")
     private String content;
 
+    @Builder
     public Comment (Event event,User user,String content){
         this.event=event;
         this.user=user;
         this.content=content;
     }
+
     public void update (String content){
         this.content=content;
     }
-
-
 }

--- a/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Event.java
+++ b/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Event.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +13,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class Event {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "event_id")
@@ -47,14 +47,13 @@ public class Event {
     private String type;
 
     @ManyToOne
-    @Column(nullable = false, name = "cate")
+    @JoinColumn(name="category_id")
     private Category cate;
 
+    @Builder
     public Event (String title,String date,String price,String location,String address,String host,String link){
         this.title=title;
         this.date=date;
         this.price=price;
     }
-
-
 }

--- a/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Heart.java
+++ b/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Heart.java
@@ -3,28 +3,32 @@ package com.damoacon.app.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name="like")
+@Table(name="heart")
 @Getter
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
-public class Like {
+public class Heart {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "like_id")
+    @Column(name = "heart_id")
     private Long id;
 
     @ManyToOne
+    @JoinColumn(name="user_id")
     @NotNull
     private User user;
 
     @ManyToOne
+    @JoinColumn(name="event_id")
     @NotNull
     private Event event;
 
-    public Like (User user,Event event){
+    @Builder
+    public Heart(User user, Event event){
         this.event=event;
         this.user=user;
     }

--- a/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Interest.java
+++ b/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Interest.java
@@ -3,6 +3,7 @@ package com.damoacon.app.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,13 +18,16 @@ public class Interest {
     private Long id;
 
     @ManyToOne
+    @JoinColumn(name="user_id")
     @NotNull
     private User user;
 
     @ManyToOne
+    @JoinColumn(name="category_id")
     @NotNull
     private Category cate;
 
+    @Builder
     public Interest(User user, Category cate){
         this.user=user;
         this.cate=cate;

--- a/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Survey.java
+++ b/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/Survey.java
@@ -2,6 +2,7 @@ package com.damoacon.app.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,9 +22,10 @@ public class Survey {
     private String answer;
 
     @OneToOne
-    @Column(nullable = false, name = "event")
+    @PrimaryKeyJoinColumn
     private Event event;
 
+    @Builder
     public Survey (String question,String answer,Event event){
         this.question=question;
         this.answer=answer;

--- a/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/User.java
+++ b/SpringBoot-Damoacon/src/main/java/com/damoacon/app/entity/User.java
@@ -3,11 +3,12 @@ package com.damoacon.app.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name="users")
+@Table(name="user")
 @Getter
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 public class User {
@@ -24,7 +25,7 @@ public class User {
     @Column(nullable = false, name = "profile")
     private String profile;
 
-
+    @Builder
     public User (String email,String username,String profile){
         this.email=email;
         this.username=username;


### PR DESCRIPTION
엔티티 오류 났던 부분 수정.
like 테이블 오류 났던 원인: mysql에서 like가 예약된 명령어라서 -> Heart로 이름 바꿔줌.
ManyToOne 필드 오류 원인: Column 어노테이션이 대신에 JoinColumn 어노테이션을 사용하라는 오류메시지 뜸. -> 변경 완료